### PR TITLE
fix section declaration of startup_early_hook()

### DIFF
--- a/src/hal/TEENSY_40/hal.c
+++ b/src/hal/TEENSY_40/hal.c
@@ -649,7 +649,7 @@ void start_up( void ) {
      __asm__ volatile( "MOV PC, LR" );*/
 }
 //----------------------------------------------------------------------------------
-void startup_early_hook( void ) {
+FLASHMEM void startup_early_hook( void ) {
     uint32_t OR_D_GPR = IOMUXC_GPR_GPR4 | IOMUXC_GPR_GPR7 | IOMUXC_GPR_GPR8 | IOMUXC_GPR_GPR12;
     if ( OR_D_GPR > 0x0 ) {
         IOMUXC_GPR_GPR1 &= ~IOMUXC_GPR_GPR1_GINT;


### PR DESCRIPTION
startup_early_hook() has to reside in FLASHMEM as RAM isn't initialized yet. Also related to the "9 blinks = ARM JTAG DAP Init Error" described in https://www.pjrc.com/store/ic_mkl02_t4.html. See also core/startup.c in "cores" repo. Has been previously discussed in https://forum.pjrc.com/threads/69432-Snooze-not-working-with-any-T4-x-on-TD1-56?p=299369&viewfull=1#post299369 and fix has been verified to be required in order to create a successfully booting image.