### PR TITLE
Fix issue with wakeup using multiple GPIOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Snooze v6.3.9
+# Snooze v6.3.10
 
 ---
 Low power library for the Teensy LC/3.2/3.5/3.6/4.0 class microcontrollers.
@@ -12,7 +12,7 @@ This is a maintenance update because of a change in the new class structure whic
 ***
 
 Example usage:
-```
+```c++
 #include <Snooze.h>
 // Load drivers
 SnoozeDigital digital;
@@ -20,33 +20,33 @@ SnoozeDigital digital;
 // install drivers to a SnoozeBlock
 SnoozeBlock config(digital);
 void setup() {
-pinMode(LED_BUILTIN, OUTPUT);
-/********************************************************
-Define digital pins for waking the teensy up. This
-combines pinMode and attachInterrupt in one function.
+    pinMode(LED_BUILTIN, OUTPUT);
+    /********************************************************
+    Define digital pins for waking the Teensy up. This
+    combines pinMode and attachInterrupt in one function.
 
-Teensy 4.0
-Digtal pins: all pins
+    Teensy 4.0
+    Digital pins: all pins
 
-Teensy 3.x
-Digital pins: 2,4,6,7,9,10,11,13,16,21,22,26,30,33
+    Teensy 3.x
+    Digital pins: 2,4,6,7,9,10,11,13,16,21,22,26,30,33
 
-Teensy LC
-Digital pins: 2,6,7,9,10,11,16,21,22
-********************************************************/
-digital.pinMode(21, INPUT_PULLUP, RISING);//pin, mode, type
-digital.pinMode(22, INPUT_PULLUP, RISING);//pin, mode, type
+    Teensy LC
+    Digital pins: 2,6,7,9,10,11,16,21,22
+    ********************************************************/
+    digital.pinMode(21, INPUT_PULLUP, RISING);//pin, mode, type
+    digital.pinMode(22, INPUT_PULLUP, RISING);//pin, mode, type
 }
 
 void loop() {
-/********************************************************
-feed the sleep function its wakeup parameters. Then go
-to deepSleep.
-********************************************************/
-int who = Snooze.deepSleep( config );// return module that woke processor
-digitalWrite(LED_BUILTIN, HIGH);
-delay(100);
-digitalWrite(LED_BUILTIN, LOW);
+    /********************************************************
+    feed the sleep function its wakeup parameters. Then go
+    to deepSleep.
+    ********************************************************/
+    int who = Snooze.deepSleep( config );// return module that woke processor
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(100);
+    digitalWrite(LED_BUILTIN, LOW);
 }
 ```
 
@@ -61,7 +61,7 @@ Current Divers:
 8. spi       - Configures the spi pins for low power, does not wake the teensy up.
 
 Next we see the SnoozeBlock only has the timer and digital drivers installed. Even though the Touch driver is loaded it is not installed so it won't get called. In this example either the timer expires or the digital pin is lifted will wake the Teensy up.<br>
-```c
+```c++
 #include <Snooze.h>
 // Load drivers
 SnoozeTouch touch;
@@ -72,38 +72,38 @@ SnoozeTimer timer;
 SnoozeBlock config(timer, digital);
 
 void setup() {
-pinMode(LED_BUILTIN, OUTPUT);
-/********************************************************
-* Set Low Power Timer wake up in milliseconds T3.x/LC, 
-* seconds T4.x.
-********************************************************/
-timer.setTimer(5000);// milliseconds
-/********************************************************
-* Define digital pins for waking the teensy up. This
-* combines pinMode and attachInterrupt in one function.
-* 
-* Teensy 4.0
-* Digtal pins: all pins
-*
-* Teensy 3.x
-* Digital pins: 2,4,6,7,9,10,11,13,16,21,22,26,30,33
-*
-* Teensy LC
-* Digital pins: 2,6,7,9,10,11,16,21,22
-********************************************************/
-digital.pinMode(21, INPUT_PULLUP, RISING);//pin, mode, type
-digital.pinMode(22, INPUT_PULLUP, RISING);//pin, mode, type
+    pinMode(LED_BUILTIN, OUTPUT);
+    /********************************************************
+    * Set Low Power Timer wake up in milliseconds T3.x/LC, 
+    * seconds T4.x.
+    ********************************************************/
+    timer.setTimer(5000);// milliseconds
+    /********************************************************
+    * Define digital pins for waking the Teensy up. This
+    * combines pinMode and attachInterrupt in one function.
+    * 
+    * Teensy 4.0
+    * Digtal pins: all pins
+    *
+    * Teensy 3.x
+    * Digital pins: 2,4,6,7,9,10,11,13,16,21,22,26,30,33
+    *
+    * Teensy LC
+    * Digital pins: 2,6,7,9,10,11,16,21,22
+    ********************************************************/
+    digital.pinMode(21, INPUT_PULLUP, RISING);//pin, mode, type
+    digital.pinMode(22, INPUT_PULLUP, RISING);//pin, mode, type
 }
 
 void loop() {
-/********************************************************
-* feed the sleep function its wakeup parameters. Then go 
-* to deepSleep.
-********************************************************/
-int who = Snooze.deepSleep( config );// return module that woke processor
-digitalWrite(LED_BUILTIN, HIGH);
-delay(100);
-digitalWrite(LED_BUILTIN, LOW);
+    /********************************************************
+    * feed the sleep function its wakeup parameters. Then go 
+    * to deepSleep.
+    ********************************************************/
+    int who = Snooze.deepSleep( config );// return module that woke processor
+    digitalWrite(LED_BUILTIN, HIGH);
+    delay(100);
+    digitalWrite(LED_BUILTIN, LOW);
 }
 ```
 <b>Lets break out each part out so we can see what is going on here:</b><br>

--- a/examples/deepsleep/sd_datalogger/sd_datalogger.ino
+++ b/examples/deepsleep/sd_datalogger/sd_datalogger.ino
@@ -186,7 +186,6 @@ void logData(uint32_t count) {
     dataFile.print(dataString);
     dataFile.close();
     // print to the serial port too:
-    int len = dataString.length();
     usb.print(dataString);
   }
   // if the file isn't open, pop up an error:
@@ -246,7 +245,7 @@ void sdCardInfo() {
   usb.println(volumesize);
 
   usb.println("\nFiles found on the card (name, date and size in bytes): ");
-  root.openRoot(volume);
+  root.open("/");
 
   // list all files in the card with date and size
   root.ls(LS_R | LS_DATE | LS_SIZE);

--- a/examples/deepsleep/simple_datalogger/simple_datalogger.ino
+++ b/examples/deepsleep/simple_datalogger/simple_datalogger.ino
@@ -28,11 +28,6 @@ const uint8_t BUTTON = 7;
 // use bounce for pin 4, debounce of 5ms
 Bounce button = Bounce(BUTTON, 5);
 
-// buffer to hold data for printing, this is because the -
-// Serial Monitor takes a few seconds to come back online -
-// after waking up from sleep mode
-static char print_buffer[2000] = {0};
-
 // install driver into SnoozeBlock
 #if defined(__IMXRT1062__) | defined(__MK66FX1M0__) || defined(__MK64FX512__) || defined(__MK20DX256__)
 SnoozeBlock config_teensy(usb, digital);

--- a/examples/hibernate/sd_datalogger/sd_datalogger.ino
+++ b/examples/hibernate/sd_datalogger/sd_datalogger.ino
@@ -190,7 +190,6 @@ void logData(uint32_t count) {
     dataFile.print(dataString);
     dataFile.close();
     // print to the serial port too:
-    int len = dataString.length();
     usb.print(dataString);
   }
   // if the file isn't open, pop up an error:
@@ -250,7 +249,7 @@ void sdCardInfo() {
   usb.println(volumesize);
 
   usb.println("\nFiles found on the card (name, date and size in bytes): ");
-  root.openRoot(volume);
+  root.open("/");
 
   // list all files in the card with date and size
   root.ls(LS_R | LS_DATE | LS_SIZE);

--- a/examples/reduced_cpu_block/HardwareSerial/HardwareSerial.ino
+++ b/examples/reduced_cpu_block/HardwareSerial/HardwareSerial.ino
@@ -18,13 +18,13 @@ HardwareSerial1_LP serial1(115200);
 // install low power hardware serial driver to a SnoozeBlock
 SnoozeBlock serialConfig(serial1);
 
-elapsedMillis time;
+elapsedMillis timeMsec;
 
 void setup() {
     pinMode(LED_BUILTIN, OUTPUT);
     // start Serial1 normally at F_CPU
     Serial1.begin(115200);
-    time = 0;
+    timeMsec = 0;
 }
 
 
@@ -41,10 +41,10 @@ void loop() {
         // print serial1 with cpu running at 2 MHz
         Serial1.print("2_MHZ:\t2000000\n");
         Serial1.flush();
-        time = 0;
+        timeMsec = 0;
         // see delay.c
         delay_lp(1000);
-        uint32_t t = time;
+        uint32_t t = timeMsec;
         Serial1.printf("DELAY:\t%i\n", t);
         Serial1.println("----------------------------------------");
         Serial1.flush();

--- a/examples/reduced_cpu_block/HardwareSerial/HardwareSerial1_LP.h
+++ b/examples/reduced_cpu_block/HardwareSerial/HardwareSerial1_LP.h
@@ -5,9 +5,11 @@
 //
 
 #if defined(HAS_KINETISK_UART0)
+#define TWO_MHZ 2000000
 #define BAUD2DIV_2MHZ(baud) (((TWO_MHZ * 2) + ((baud) >> 1)) / (baud))
 #elif defined(HAS_KINETISL_UART0)
 // LC uses OSCERCLK, which is 16 MHz. Oversample rate is 4.
+#define SIXTEEN_MHZ 16000000
 #define BAUD2DIV_2MHZ(baud) (((SIXTEEN_MHZ / 4) + ((baud) >> 1)) / (baud))
 
 #define SIM_SOPT2_UART0SRC_MASK 0x0C000000

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Snooze
-version=6.3.9
+version=6.3.10
 author=Colin Duffy
 maintainer=Colin Duffy
 sentence=Low Power for Teensy 4.x/3.x/LC

--- a/revision.md
+++ b/revision.md
@@ -1,7 +1,11 @@
-Updated (10/10/20 v6.3.9)
-Updated T4 SPI driver.
-Changed Button Hold example pin to 6.
-Updated start early hook in T4.
+><b>Updated (2025-11-09 v6.3.10)</b><br>
+* Synced with current Teensyduino  release (1.59)
+* Fix issue with multiple-GPIO wakeup on Teensy 4.x
+
+><b>Updated (10/10/20 v6.3.9)</b><br>
+* Updated T4 SPI driver.
+* Changed Button Hold example pin to 6.
+* Updated start early hook in T4.
 
 ><b>Updated (4/20/20 v6.3.8)</b><br>
 * Maintenance release.<br>

--- a/src/hal/TEENSY_40/SnoozeCompare.cpp
+++ b/src/hal/TEENSY_40/SnoozeCompare.cpp
@@ -171,53 +171,52 @@ void SnoozeCompare::pinMode( int _pin, int _type, float val ) {
  *******************************************************************************/
 void SnoozeCompare::disableDriver( uint8_t mode ) {
     if ( mode == 0 ) return;
-    IRQ_NUMBER_t IRQ_CMP;
     if ( mode == 1 ) {
+        IRQ_NUMBER_t irq;
         switch ( pin ) {
             case 0:
-                IRQ_CMP = IRQ_ACMP4;
+                irq = IRQ_ACMP4;
                 break;
             case 1:
-                IRQ_CMP = IRQ_ACMP3;
+                irq = IRQ_ACMP3;
                 break;
             case 14:
-                IRQ_CMP = IRQ_ACMP1;
+                irq = IRQ_ACMP1;
                 break;
             case 15:
-                IRQ_CMP = IRQ_ACMP2;
+                irq = IRQ_ACMP2;
                 break;
             case 16:
-                IRQ_CMP = IRQ_ACMP1;
+                irq = IRQ_ACMP1;
                 break;
             case 17:
-                IRQ_CMP = IRQ_ACMP1;
+                irq = IRQ_ACMP1;
                 break;
             case 18:
-                IRQ_CMP = IRQ_ACMP1;
+                irq = IRQ_ACMP1;
                 break;
             case 19:
-                IRQ_CMP = IRQ_ACMP4;
+                irq = IRQ_ACMP4;
                 break;
             case 20:
-                IRQ_CMP = IRQ_ACMP4;
+                irq = IRQ_ACMP4;
                 break;
             case 21:
-                IRQ_CMP = IRQ_ACMP1;
+                irq = IRQ_ACMP1;
                 break;
             case 22:
-                IRQ_CMP = IRQ_ACMP2;
+                irq = IRQ_ACMP2;
                 break;
             case 23:
-                IRQ_CMP = IRQ_ACMP3;
+                irq = IRQ_ACMP3;
                 break;
             default:
-                IRQ_CMP = IRQ_CMP;
-                break;
+		return;
         }
-        if ( return_isr_enabled == 0 ) NVIC_DISABLE_IRQ( IRQ_CMP );
-        NVIC_SET_PRIORITY( IRQ_CMP, return_priority );
+        if ( return_isr_enabled == 0 ) NVIC_DISABLE_IRQ( irq );
+        NVIC_SET_PRIORITY( irq, return_priority );
         __disable_irq( );
-        attachInterruptVector( IRQ_CMP, return_cmp_irq );// return prev interrupt
+        attachInterruptVector( irq, return_cmp_irq );// return prev interrupt
         __enable_irq( );
     }
     switch (pin) {
@@ -299,59 +298,60 @@ void SnoozeCompare::disableDriver( uint8_t mode ) {
  *******************************************************************************/
 void SnoozeCompare::enableDriver( uint8_t mode ) {
     if (mode == 0) return;
-    IRQ_NUMBER_t IRQ_CMP;
+    IRQ_NUMBER_t irq;
     if ( mode == 1 ) {
         switch ( pin ) {
             case 0:
-                IRQ_CMP = IRQ_ACMP4;
+                irq = IRQ_ACMP4;
                 break;
             case 1:
-                IRQ_CMP = IRQ_ACMP3;
+                irq = IRQ_ACMP3;
                 break;
             case 14:
-                IRQ_CMP = IRQ_ACMP1;
+                irq = IRQ_ACMP1;
                 break;
             case 15:
-                IRQ_CMP = IRQ_ACMP2;
+                irq = IRQ_ACMP2;
                 break;
             case 16:
-                IRQ_CMP = IRQ_ACMP1;
+                irq = IRQ_ACMP1;
                 break;
             case 17:
-                IRQ_CMP = IRQ_ACMP1;
+                irq = IRQ_ACMP1;
                 break;
             case 18:
-                IRQ_CMP = IRQ_ACMP1;
+                irq = IRQ_ACMP1;
                 break;
             case 19:
-                IRQ_CMP = IRQ_ACMP4;
+                irq = IRQ_ACMP4;
                 break;
             case 20:
-                IRQ_CMP = IRQ_ACMP4;
+                irq = IRQ_ACMP4;
                 break;
             case 21:
-                IRQ_CMP = IRQ_ACMP1;
+                irq = IRQ_ACMP1;
                 break;
             case 22:
-                IRQ_CMP = IRQ_ACMP2;
+                irq = IRQ_ACMP2;
                 break;
             case 23:
-                IRQ_CMP = IRQ_ACMP3;
+                irq = IRQ_ACMP3;
                 break;
             default:
-                IRQ_CMP = IRQ_CMP;
-                break;
+                return;
         }
-        return_priority = NVIC_GET_PRIORITY( IRQ_CMP );//get current priority
+        return_priority = NVIC_GET_PRIORITY( irq );//get current priority
         
         int priority = nvic_execution_priority( );// get current priority
         // if running from handler mode set priority higher than current handler
         priority = ( priority < 256 ) && ( ( priority - 16 ) > 0 ) ? priority - 16 : 128;
-        NVIC_SET_PRIORITY( IRQ_CMP, priority );//set priority to new level
+        NVIC_SET_PRIORITY( irq, priority );//set priority to new level
         __disable_irq( );
-        return_cmp_irq = _VectorsRam[IRQ_CMP+16];// save prev isr
-        attachInterruptVector( IRQ_CMP, wakeup_isr );
+        return_cmp_irq = _VectorsRam[irq+16];// save prev isr
+        attachInterruptVector( irq, wakeup_isr );
         __enable_irq( );
+    } else {
+        return;
     }
     
     CR0 = *cmpx_cr0;
@@ -479,8 +479,8 @@ void SnoozeCompare::enableDriver( uint8_t mode ) {
         default:
             break;
     }
-    return_isr_enabled = NVIC_IS_ENABLED( IRQ_CMP );
-    if ( return_isr_enabled == 0 ) NVIC_ENABLE_IRQ( IRQ_CMP );
+    return_isr_enabled = NVIC_IS_ENABLED( irq );
+    if ( return_isr_enabled == 0 ) NVIC_ENABLE_IRQ( irq );
     
     // setup compare
     *cmpx_cr0 = CMP_CR0_FILTER_CNT( 0x07 );

--- a/src/hal/TEENSY_40/SnoozeDigital.cpp
+++ b/src/hal/TEENSY_40/SnoozeDigital.cpp
@@ -9,14 +9,14 @@
 
 #include "SnoozeDigital.h"
 
-#define DR    0
-#define GDIR  1
-#define PSR   2
-#define ICR1  3
-#define ICR2  4
-#define IMR   5
-#define ISR   6
-#define EDGE  7
+//#define DR    0
+#define GPIO_INDEX_GDIR  1
+#define GPIO_INDEX_PSR   2
+#define GPIO_INDEX_ICR1  3
+#define GPIO_INDEX_ICR2  4
+#define GPIO_INDEX_IMR   5
+#define GPIO_INDEX_ISR   6
+#define GPIO_INDEX_EDGE  7
 
 #ifdef __cplusplus
 extern "C" {
@@ -96,7 +96,7 @@ void SnoozeDigital::enableDriver( uint8_t mode ) {
         if ( mode == 3 ) {
             volatile uint32_t *gpio = portOutputRegister( pinNumber );
             switch( ( uint32_t )gpio ) {
-                case ( uint32_t )&GPIO6_DR: {
+                case IMXRT_GPIO6_ADDRESS: {
                     if ( ( GPIO1_IMR & 0xFFFF0000 ) && return_gpio1_16_31_irq == 0 ) {
                         return_isr_gpio1_16_31_enabled = NVIC_IS_ENABLED( IRQ_GPIO1_16_31 );
                         NVIC_DISABLE_IRQ( IRQ_GPIO1_16_31 );
@@ -129,7 +129,7 @@ void SnoozeDigital::enableDriver( uint8_t mode ) {
                     IOMUXC_GPR_GPR26 &= ~( GPIO1_IMR & 0xFFFF );
                     break;
                 }
-                case ( uint32_t )&GPIO7_DR: {
+                case IMXRT_GPIO7_ADDRESS: {
                     if ( ( GPIO2_IMR & 0xFFFF0000 ) && return_gpio2_16_31_irq == 0 ) {
                         return_isr_gpio2_16_31_enabled = NVIC_IS_ENABLED( IRQ_GPIO2_16_31 );
                         NVIC_DISABLE_IRQ( IRQ_GPIO2_16_31 );
@@ -162,7 +162,7 @@ void SnoozeDigital::enableDriver( uint8_t mode ) {
                     IOMUXC_GPR_GPR27 &= ~( GPIO2_IMR & 0xFFFF );
                     break;
                 }
-                case ( uint32_t )&GPIO8_DR: {
+                case IMXRT_GPIO8_ADDRESS: {
                     if ( ( GPIO3_IMR & 0xFFFF0000 ) && return_gpio3_16_31_irq == 0 ) {
                         return_isr_gpio3_16_31_enabled = NVIC_IS_ENABLED( IRQ_GPIO3_16_31 );
                         NVIC_DISABLE_IRQ( IRQ_GPIO3_16_31 );
@@ -195,7 +195,7 @@ void SnoozeDigital::enableDriver( uint8_t mode ) {
                     IOMUXC_GPR_GPR28 &= ~( GPIO3_IMR & 0xFFFF );
                     break;
                 }
-                case ( uint32_t )&GPIO9_DR: {
+                case IMXRT_GPIO9_ADDRESS: {
                     if ( ( GPIO4_IMR & 0xFFFF0000 ) && return_gpio4_16_31_irq == 0 ) {
                         return_isr_gpio4_16_31_enabled = NVIC_IS_ENABLED( IRQ_GPIO4_16_31 );
                         NVIC_DISABLE_IRQ( IRQ_GPIO4_16_31 );
@@ -266,7 +266,7 @@ void SnoozeDigital::disableDriver( uint8_t mode ) {
         if ( mode == 3 ) {
             volatile uint32_t *gpio = portOutputRegister( pinNumber );
             switch( ( uint32_t )gpio ) {
-                case ( uint32_t )&GPIO6_DR: {
+                case IMXRT_GPIO6_ADDRESS: {
                     if ( ( GPIO1_IMR & 0xFFFF0000 ) && return_gpio1_16_31_irq != 0 ) {
                         NVIC_SET_PRIORITY( IRQ_GPIO1_16_31, return_priority_gpio1_16_31 );
                         __disable_irq( );
@@ -289,7 +289,7 @@ void SnoozeDigital::disableDriver( uint8_t mode ) {
                     IOMUXC_GPR_GPR26 |= ( GPIO1_IMR & 0xFFFF );
                     break;
                 }
-                case ( uint32_t )&GPIO7_DR: {
+                case IMXRT_GPIO7_ADDRESS: {
                     if ( ( GPIO2_IMR & 0xFFFF0000 ) ) {
                         NVIC_SET_PRIORITY( IRQ_GPIO2_16_31, return_priority_gpio2_16_31 );
                         __disable_irq( );
@@ -312,7 +312,7 @@ void SnoozeDigital::disableDriver( uint8_t mode ) {
                     IOMUXC_GPR_GPR27 |= ( GPIO2_IMR & 0xFFFF );
                     break;
                 }
-                case ( uint32_t )&GPIO8_DR: {
+                case IMXRT_GPIO8_ADDRESS: {
                     if ( ( GPIO3_IMR & 0xFFFF0000 ) && return_gpio2_16_31_irq != 0 ) {
                         NVIC_SET_PRIORITY( IRQ_GPIO3_16_31, return_priority_gpio3_16_31 );
                         __disable_irq( );
@@ -335,7 +335,7 @@ void SnoozeDigital::disableDriver( uint8_t mode ) {
                     IOMUXC_GPR_GPR28 |= ( GPIO3_IMR & 0xFFFF );
                     break;
                 }
-                case ( uint32_t )&GPIO9_DR: {
+                case IMXRT_GPIO9_ADDRESS: {
                     if ( ( GPIO4_IMR & 0xFFFF0000 ) && return_gpio4_16_31_irq != 0 ) {
                         NVIC_SET_PRIORITY( IRQ_GPIO4_16_31, return_priority_gpio4_16_31 );
                         __disable_irq( );
@@ -386,25 +386,25 @@ void SnoozeDigital::clearIsrFlags( uint32_t ipsr ) {
         volatile uint32_t *gpio = portOutputRegister( pinNumber );
         if ( sleep_type == 3 ) {
             switch( ( uint32_t )gpio ) {
-                case ( uint32_t )&GPIO6_DR:
+                case IMXRT_GPIO6_ADDRESS:
                     gpio = &GPIO1_DR;
                     break;
-                case ( uint32_t )&GPIO7_DR:
+                case IMXRT_GPIO7_ADDRESS:
                     gpio = &GPIO2_DR;
                     break;
-                case ( uint32_t )&GPIO8_DR:
+                case IMXRT_GPIO8_ADDRESS:
                     gpio = &GPIO3_DR;
                     break;
-                case ( uint32_t )&GPIO9_DR:
+                case IMXRT_GPIO9_ADDRESS:
                     gpio = &GPIO4_DR;
                     break;
                 default:
                     break;
             }
         }
-        uint32_t status = gpio[ISR] & gpio[IMR];
+        uint32_t status = gpio[GPIO_INDEX_ISR] & gpio[GPIO_INDEX_IMR];
         if ( status ) {
-            gpio[ISR] = status;
+            gpio[GPIO_INDEX_ISR] = status;
         }
         detachDigitalInterrupt( pinNumber );// remove pin interrupt
     }
@@ -421,16 +421,16 @@ void SnoozeDigital::attachDigitalInterrupt( uint8_t pin, int type ) {
     volatile uint32_t *gpio = portOutputRegister( pin );
     if ( sleep_type == 3 ) {
         switch( ( uint32_t )gpio ) {
-            case ( uint32_t )&GPIO6_DR:
+            case IMXRT_GPIO6_ADDRESS:
                 gpio = &GPIO1_DR;
                 break;
-            case ( uint32_t )&GPIO7_DR:
+            case IMXRT_GPIO7_ADDRESS:
                 gpio = &GPIO2_DR;
                 break;
-            case ( uint32_t )&GPIO8_DR:
+            case IMXRT_GPIO8_ADDRESS:
                 gpio = &GPIO3_DR;
                 break;
-            case ( uint32_t )&GPIO9_DR:
+            case IMXRT_GPIO9_ADDRESS:
                 gpio = &GPIO4_DR;
                 break;
             default:
@@ -450,24 +450,24 @@ void SnoozeDigital::attachDigitalInterrupt( uint8_t pin, int type ) {
         default: return;
     }
     // TODO: global interrupt disable to protect these read-modify-write accesses?
-    gpio[IMR] &= ~mask;    // disable interrupt
+    gpio[GPIO_INDEX_IMR] &= ~mask;    // disable interrupt
     *mux = 5;               // pin is GPIO
-    gpio[GDIR] &= ~mask;    // pin to input mode
+    gpio[GPIO_INDEX_GDIR] &= ~mask;    // pin to input mode
     uint32_t index = __builtin_ctz( mask );
     if ( type == CHANGE ) {
-        gpio[EDGE] |= mask;
+        gpio[GPIO_INDEX_EDGE] |= mask;
     } else {
-        gpio[EDGE] &= ~mask;
+        gpio[GPIO_INDEX_EDGE] &= ~mask;
         if ( index < 15 ) {
             uint32_t shift = index * 2;
-            gpio[ICR1] = (gpio[ICR1] & ~( 3 << shift ) ) | ( icr << shift );
+            gpio[GPIO_INDEX_ICR1] = (gpio[GPIO_INDEX_ICR1] & ~( 3 << shift ) ) | ( icr << shift );
         } else {
             uint32_t shift = ( index - 16 ) * 2;
-            gpio[ICR2] = ( gpio[ICR2] & ~( 3 << shift ) ) | ( icr << shift );
+            gpio[GPIO_INDEX_ICR2] = ( gpio[GPIO_INDEX_ICR2] & ~( 3 << shift ) ) | ( icr << shift );
         }
     }
-    gpio[ISR] = mask;  // clear any prior pending interrupt
-    gpio[IMR] |= mask; // enable interrupt
+    gpio[GPIO_INDEX_ISR] = mask;  // clear any prior pending interrupt
+    gpio[GPIO_INDEX_IMR] |= mask; // enable interrupt
 
 }
 
@@ -481,16 +481,16 @@ void SnoozeDigital::detachDigitalInterrupt( uint8_t pin ) {
     volatile uint32_t *gpio = portOutputRegister( pin );
     if ( sleep_type == 2 ) {
         switch( ( uint32_t )gpio ) {
-            case ( uint32_t )&GPIO6_DR:
+            case IMXRT_GPIO6_ADDRESS:
                 gpio = &GPIO1_DR;
                 break;
-            case ( uint32_t )&GPIO7_DR:
+            case IMXRT_GPIO7_ADDRESS:
                 gpio = &GPIO2_DR;
                 break;
-            case ( uint32_t )&GPIO8_DR:
+            case IMXRT_GPIO8_ADDRESS:
                 gpio = &GPIO3_DR;
                 break;
-            case ( uint32_t )&GPIO9_DR:
+            case IMXRT_GPIO9_ADDRESS:
                 gpio = &GPIO4_DR;
                 break;
             default:
@@ -498,6 +498,6 @@ void SnoozeDigital::detachDigitalInterrupt( uint8_t pin ) {
         }
     }
     uint32_t mask = digitalPinToBitMask( pin );
-    gpio[IMR] &= ~mask;
+    gpio[GPIO_INDEX_IMR] &= ~mask;
 }
 #endif /* __IMXRT1062__ */

--- a/src/hal/TEENSY_40/SnoozeDigital.cpp
+++ b/src/hal/TEENSY_40/SnoozeDigital.cpp
@@ -260,6 +260,11 @@ void SnoozeDigital::enableDriver( uint8_t mode ) {
 void SnoozeDigital::disableDriver( uint8_t mode ) {
     if (mode == 0) return;
     uint64_t _pin = pin;
+
+    // seem to be able to get spurious interrupts during teardown:
+    // mask all interrupts while we're messing with _VectorsRam[]
+    __disable_irq( );
+
     while ( __builtin_popcountll( _pin ) ) {
         uint32_t pinNumber = 63 - __builtin_clzll( _pin );
         _pin &= ~( ( uint64_t )1 << pinNumber );// remove pin from list
@@ -275,18 +280,14 @@ void SnoozeDigital::disableDriver( uint8_t mode ) {
                 case IMXRT_GPIO6_ADDRESS: {
                     if ( ( GPIO1_IMR & 0xFFFF0000 ) && return_gpio1_16_31_irq != 0 ) {
                         NVIC_SET_PRIORITY( IRQ_GPIO1_16_31, return_priority_gpio1_16_31 );
-                        __disable_irq( );
                         attachInterruptVector( IRQ_GPIO1_16_31, return_gpio1_16_31_irq );// set previous isr func
-                        __enable_irq( );
                         return_gpio1_16_31_irq = 0;
                         if ( return_isr_gpio1_16_31_enabled == 0 ) NVIC_DISABLE_IRQ( IRQ_GPIO1_16_31 );
                         //IOMUXC_GPR_GPR26 |= ( GPIO1_IMR & 0xFFFF0000 );
                     }
                     if ( ( GPIO1_IMR & 0xFFFF ) && return_gpio1_0_15_irq != 0 ) {
                         NVIC_SET_PRIORITY( IRQ_GPIO1_0_15, return_priority_gpio1_0_15 );
-                        __disable_irq( );
                         attachInterruptVector( IRQ_GPIO1_0_15, return_gpio1_0_15_irq );// set previous isr func
-                        __enable_irq( );
                         return_gpio1_0_15_irq = 0;
                         if ( return_isr_gpio1_0_15_enabled == 0 ) NVIC_DISABLE_IRQ( IRQ_GPIO1_0_15 );
                         //IOMUXC_GPR_GPR26 |= ( GPIO1_IMR & 0xFFFF );
@@ -298,18 +299,14 @@ void SnoozeDigital::disableDriver( uint8_t mode ) {
                 case IMXRT_GPIO7_ADDRESS: {
                     if ( ( GPIO2_IMR & 0xFFFF0000 ) ) {
                         NVIC_SET_PRIORITY( IRQ_GPIO2_16_31, return_priority_gpio2_16_31 );
-                        __disable_irq( );
                         attachInterruptVector( IRQ_GPIO2_16_31, return_gpio2_16_31_irq );// set previous isr func
-                        __enable_irq( );
                         return_gpio2_16_31_irq = 0;
                         if ( return_isr_gpio2_16_31_enabled == 0 ) NVIC_DISABLE_IRQ( IRQ_GPIO2_16_31 );
                         //IOMUXC_GPR_GPR27 |= ( GPIO2_IMR & 0xFFFF0000 );
                     }
                     if ( ( GPIO2_IMR & 0xFFFF ) && return_gpio2_0_15_irq != 0 ) {
                         NVIC_SET_PRIORITY( IRQ_GPIO2_0_15, return_priority_gpio2_0_15 );
-                        __disable_irq( );
                         attachInterruptVector( IRQ_GPIO2_0_15, return_gpio2_0_15_irq );// set previous isr func
-                        __enable_irq( );
                         return_gpio2_0_15_irq = 0;
                         if ( return_isr_gpio2_0_15_enabled == 0 ) NVIC_DISABLE_IRQ( IRQ_GPIO2_0_15 );
                         //IOMUXC_GPR_GPR27 |= ( GPIO2_IMR & 0xFFFF );
@@ -321,18 +318,14 @@ void SnoozeDigital::disableDriver( uint8_t mode ) {
                 case IMXRT_GPIO8_ADDRESS: {
                     if ( ( GPIO3_IMR & 0xFFFF0000 ) && return_gpio2_16_31_irq != 0 ) {
                         NVIC_SET_PRIORITY( IRQ_GPIO3_16_31, return_priority_gpio3_16_31 );
-                        __disable_irq( );
                         attachInterruptVector( IRQ_GPIO3_16_31, return_gpio3_16_31_irq );// set previous isr func
-                        __enable_irq( );
                         return_gpio3_16_31_irq = 0;
                         if ( return_isr_gpio3_16_31_enabled == 0 ) NVIC_DISABLE_IRQ( IRQ_GPIO3_16_31 );
                         //IOMUXC_GPR_GPR28 |= ( GPIO3_IMR & 0xFFFF0000 );
                     }
                     if ( ( GPIO3_IMR & 0xFFFF ) && return_gpio3_0_15_irq != 0 ) {
                         NVIC_SET_PRIORITY( IRQ_GPIO3_0_15, return_priority_gpio3_0_15 );
-                        __disable_irq( );
                         attachInterruptVector( IRQ_GPIO3_0_15, return_gpio3_0_15_irq );// set previous isr func
-                        __enable_irq( );
                         return_gpio3_0_15_irq = 0;
                         if ( return_isr_gpio3_0_15_enabled == 0 ) NVIC_DISABLE_IRQ( IRQ_GPIO3_0_15 );
                         //IOMUXC_GPR_GPR28 |= ( GPIO3_IMR & 0xFFFF );
@@ -344,18 +337,14 @@ void SnoozeDigital::disableDriver( uint8_t mode ) {
                 case IMXRT_GPIO9_ADDRESS: {
                     if ( ( GPIO4_IMR & 0xFFFF0000 ) && return_gpio4_16_31_irq != 0 ) {
                         NVIC_SET_PRIORITY( IRQ_GPIO4_16_31, return_priority_gpio4_16_31 );
-                        __disable_irq( );
                         attachInterruptVector( IRQ_GPIO4_16_31, return_gpio4_16_31_irq );// set previous isr func
-                        __enable_irq( );
                         return_gpio4_16_31_irq = 0;
                         if ( return_isr_gpio4_16_31_enabled == 0 ) NVIC_DISABLE_IRQ( IRQ_GPIO4_16_31 );
                         //IOMUXC_GPR_GPR29 |= ( GPIO4_IMR & 0xFFFF0000 );
                     }
                     if ( ( GPIO4_IMR & 0xFFFF ) && return_gpio4_0_15_irq != 0 ) {
                         NVIC_SET_PRIORITY( IRQ_GPIO4_0_15, return_priority_gpio4_0_15 );
-                        __disable_irq( );
                         attachInterruptVector( IRQ_GPIO4_0_15, return_gpio4_0_15_irq );// set previous isr func
-                        __enable_irq( );
                         return_gpio4_0_15_irq = 0;
                         if ( return_isr_gpio4_0_15_enabled == 0 ) NVIC_DISABLE_IRQ( IRQ_GPIO4_0_15 );
                         //IOMUXC_GPR_GPR29 |= ( GPIO4_IMR & 0xFFFF );
@@ -374,14 +363,15 @@ void SnoozeDigital::disableDriver( uint8_t mode ) {
             if (nullptr != return_gpio6789_irq)
             {
                 NVIC_SET_PRIORITY( IRQ_GPIO6789, return_priority_gpio6789 );
-                __disable_irq( );
                 attachInterruptVector( IRQ_GPIO6789, return_gpio6789_irq );// set previous isr func
-                __enable_irq( );
                 return_gpio6789_irq = nullptr;
                 if ( return_isr_gpio6789_enabled == 0 ) NVIC_DISABLE_IRQ( IRQ_GPIO6789 );
             }
         }
     }
+
+    // should be safe to do this now:
+    __enable_irq( );
 }
 
 /*******************************************************************************

--- a/src/hal/TEENSY_40/SnoozeDigital.cpp
+++ b/src/hal/TEENSY_40/SnoozeDigital.cpp
@@ -233,23 +233,29 @@ void SnoozeDigital::enableDriver( uint8_t mode ) {
             }
         }
         else if ( mode <= 2 ) {
-            return_isr_gpio6789_enabled = NVIC_IS_ENABLED( IRQ_GPIO6789 );
-            NVIC_DISABLE_IRQ( IRQ_GPIO6789 );
-            NVIC_CLEAR_PENDING( IRQ_GPIO6789 );
-            return_priority_gpio6789 = NVIC_GET_PRIORITY( IRQ_GPIO6789 );//get current priority
-            NVIC_SET_PRIORITY( IRQ_GPIO6789, priority );//set priority to new level
-            __disable_irq( );
-            return_gpio6789_irq = _VectorsRam[IRQ_GPIO6789+16];// save prev isr handler
-            __disable_irq( );
-            attachInterruptVector( IRQ_GPIO6789, &wakeup_isr );
-            __enable_irq( );
-            NVIC_ENABLE_IRQ( IRQ_GPIO6789 );
+            // Only hook in once, no matter how many
+            // GPIO pins have been assigned to wake-up
+            if (nullptr == return_gpio6789_irq)
+            {
+                return_isr_gpio6789_enabled = NVIC_IS_ENABLED( IRQ_GPIO6789 );
+                NVIC_DISABLE_IRQ( IRQ_GPIO6789 );
+                NVIC_CLEAR_PENDING( IRQ_GPIO6789 );
+                return_priority_gpio6789 = NVIC_GET_PRIORITY( IRQ_GPIO6789 );//get current priority
+                NVIC_SET_PRIORITY( IRQ_GPIO6789, priority );//set priority to new level
+                __disable_irq( );
+                return_gpio6789_irq = _VectorsRam[IRQ_GPIO6789+16]; // save prev ISR handler: hack, no official access
+                __disable_irq( );
+                attachInterruptVector( IRQ_GPIO6789, &wakeup_isr );
+                __enable_irq( );
+                NVIC_ENABLE_IRQ( IRQ_GPIO6789 );
+            }
         }
     }
 }
 
 /*******************************************************************************
- *  Disable interrupt and configure pin to orignal state.
+ *  Disable interrupt and configure pin to original state.
+ *  Note that wakeup_isr has already masked all the wakeup pin interrupts
  *******************************************************************************/
 void SnoozeDigital::disableDriver( uint8_t mode ) {
     if (mode == 0) return;
@@ -262,7 +268,7 @@ void SnoozeDigital::disableDriver( uint8_t mode ) {
         volatile uint32_t *config;
         config = portConfigRegister( pinNumber );
         *config = return_core_pin_config[pinNumber];
-        
+
         if ( mode == 3 ) {
             volatile uint32_t *gpio = portOutputRegister( pinNumber );
             switch( ( uint32_t )gpio ) {
@@ -363,12 +369,17 @@ void SnoozeDigital::disableDriver( uint8_t mode ) {
             }
         }
         else if ( mode <= 2 ) {
-            NVIC_SET_PRIORITY( IRQ_GPIO6789, return_priority_gpio6789 );
-            __disable_irq( );
-            attachInterruptVector( IRQ_GPIO6789, return_gpio6789_irq );// set previous isr func
-            __enable_irq( );
-            return_gpio6789_irq = 0;
-            if ( return_isr_gpio6789_enabled == 0 ) NVIC_DISABLE_IRQ( IRQ_GPIO6789 );
+            // Only un-hook once, no matter how many
+            // GPIO pins have been assigned to wake-up
+            if (nullptr != return_gpio6789_irq)
+            {
+                NVIC_SET_PRIORITY( IRQ_GPIO6789, return_priority_gpio6789 );
+                __disable_irq( );
+                attachInterruptVector( IRQ_GPIO6789, return_gpio6789_irq );// set previous isr func
+                __enable_irq( );
+                return_gpio6789_irq = nullptr;
+                if ( return_isr_gpio6789_enabled == 0 ) NVIC_DISABLE_IRQ( IRQ_GPIO6789 );
+            }
         }
     }
 }
@@ -450,7 +461,7 @@ void SnoozeDigital::attachDigitalInterrupt( uint8_t pin, int type ) {
         default: return;
     }
     // TODO: global interrupt disable to protect these read-modify-write accesses?
-    gpio[GPIO_INDEX_IMR] &= ~mask;    // disable interrupt
+    gpio[GPIO_INDEX_IMR] &= ~mask;    // disable interrupt - and forget if it was enabled before (?!)
     *mux = 5;               // pin is GPIO
     gpio[GPIO_INDEX_GDIR] &= ~mask;    // pin to input mode
     uint32_t index = __builtin_ctz( mask );

--- a/src/hal/TEENSY_40/hal.c
+++ b/src/hal/TEENSY_40/hal.c
@@ -649,6 +649,7 @@ void start_up( void ) {
      __asm__ volatile( "MOV PC, LR" );*/
 }
 //----------------------------------------------------------------------------------
+FLASHMEM
 void startup_early_hook( void ) {
     uint32_t OR_D_GPR = IOMUXC_GPR_GPR4 | IOMUXC_GPR_GPR7 | IOMUXC_GPR_GPR8 | IOMUXC_GPR_GPR12;
     if ( OR_D_GPR > 0x0 ) {


### PR DESCRIPTION
See https://forum.pjrc.com/index.php?threads/teensy-4-0-sleep-with-can-wakeup.77435/ for discussion resulting in this PR

- `SnoozeDigital::enableDriver()` and `SnoozeDigital::disableDriver` were not working well for multiple GPIOs; in particular, `disableDriver` would leave the GPIO interrupt enabled
- spurious interrupts could occur during `disableDriver` execution, resulting in `unused_interrupt_vector` being called and the Teensy crashing